### PR TITLE
Allow for child to be null, convenient for optional fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,9 @@ class SettingsList extends React.Component {
     let result = [];
     let other = [];
     React.Children.forEach(this.props.children, (child) => {
+      // Allow for null, optional fields
+      if(!child) return;
+
       if(child.type.displayName === 'Header'){
         if(groupNumber != -1){
           result[groupNumber] = {items: itemGroup, header: headers[groupNumber], other: other};


### PR DESCRIPTION
Added check for if child is not null. Before having null as child would raise an error because of the `child.type` check. This makes it possible to have optional items:

`{([condition]) ? <SettingsList.Item/> : null}`

Possible use cases:
- Reusing a component, with different Items
- Extra options based on previous selections

P.S.: Great work on this! Really useful.
