### PR TITLE
Right side content

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,9 @@ class SettingsList extends React.Component {
     let result = [];
     let other = [];
     React.Children.forEach(this.props.children, (child) => {
+      // Allow for null, optional fields
+      if(!child) return;
+
       if(child.type.displayName === 'Header'){
         if(groupNumber != -1){
           result[groupNumber] = {items: itemGroup, header: headers[groupNumber], other: other};

--- a/index.js
+++ b/index.js
@@ -144,6 +144,7 @@ class SettingsList extends React.Component {
                 {item.titleInfo}
               </Text>
               : null}
+            {item.rightSideContent ? item.rightSideContent : null}
             {item.hasSwitch ?
               <Switch
                 {...item.switchProps}
@@ -267,6 +268,10 @@ SettingsList.Item = React.createClass({
      */
     titleInfo: React.PropTypes.string,
     titleInfoStyle: Text.propTypes.style,
+    /**
+     * Right side content
+     */
+    rightSideContent: React.PropTypes.node,
   },
   getDefaultProps(){
     return {


### PR DESCRIPTION
Added prop for ride side content. Allows for extra component instead of titleInfo. Use cases might be to add a segmented control or text input (I'm using it for number input). Example:

```
<SettingsList.Item
    title='Title'
    onPress={() => this.refs.textInput.focus()}
    hasNavArrow={false}
    rightSideContent={
        <TextInput
            style={{flex: 1, height: 50, marginRight:15, textAlign: 'right'}}
            value={this.state.param}
            autoCorrect={false}
            keyboardType="number-pad"
            ref="textInput"
            onChangeText={(value) => this.setState({param: value)}
        />
    }
/>
```

![img_0005](https://cloud.githubusercontent.com/assets/372756/18601800/73b9a9b4-7c65-11e6-9dab-760cec5e91cd.jpg)
