### PR TITLE
Fixed accessibility for switches

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ class SettingsList extends React.Component {
       border = index === max-1 ? {borderWidth:0} : {borderBottomWidth:1, borderColor: this.props.borderColor};
     }
     return (
-      <TouchableHighlight key={'item_' + index} underlayColor={item.underlayColor ? item.underlayColor : this.props.underlayColor} onPress={item.onPress}>
+      <TouchableHighlight accessible={false} key={'item_' + index} underlayColor={item.underlayColor ? item.underlayColor : this.props.underlayColor} onPress={item.onPress}>
         <View style={[styles.itemBox, {backgroundColor: item.backgroundColor ? item.backgroundColor : this.props.backgroundColor}]}>
           {item.icon}
           {item.isAuth ?


### PR DESCRIPTION
Disabled accessibility on the wrapping `TouchableHighlight` so that screen readers can reach the switch.