### PR TITLE
Added defaultTitleInfoPosition and titleInfoPosition props.

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ class SettingsList extends React.Component {
     borderColor: React.PropTypes.string,
     defaultItemSize: React.PropTypes.number,
     underlayColor: React.PropTypes.string,
-    defaultTitleStyle: Text.propTypes.style
+    defaultTitleStyle: Text.propTypes.style,
+    defaultTitleInfoPosition: React.PropTypes.string,
   };
 
   static defaultProps ={
@@ -103,6 +104,30 @@ class SettingsList extends React.Component {
     }
   }
 
+  _itemTitleBlock(item, index, position) {
+    return ([
+      <Text
+          key={'itemTitle_' + index}
+          style={[
+            item.titleStyle ? item.titleStyle : this.props.defaultTitleStyle,
+            position === 'Bottom' ? null : styles.titleText
+          ]}>
+          {item.title}
+      </Text>,
+      item.titleInfo ?
+        <Text
+            key={'itemTitleInfo_' + index}
+            style={[
+              position === 'Bottom' ? null : styles.rightSideStyle,
+              {color: '#B1B1B1'},
+              item.titleInfoStyle
+            ]}>
+            {item.titleInfo}
+        </Text>
+        : null
+    ])
+  }
+
   _itemView(item, index, max){
     var border;
     if(item.borderHide) {
@@ -113,6 +138,9 @@ class SettingsList extends React.Component {
     } else {
       border = index === max-1 ? {borderWidth:0} : {borderBottomWidth:1, borderColor: this.props.borderColor};
     }
+
+    let titleInfoPosition = item.titleInfoPosition ? item.titleInfoPosition : this.props.defaultTitleInfoPosition;
+
     return (
       <TouchableHighlight key={'item_' + index} underlayColor={item.underlayColor ? item.underlayColor : this.props.underlayColor} onPress={item.onPress}>
         <View style={[styles.itemBox, {backgroundColor: item.backgroundColor ? item.backgroundColor : this.props.backgroundColor}]}>
@@ -144,14 +172,12 @@ class SettingsList extends React.Component {
             </View>
           :
           <View style={[styles.titleBox, border, {height:item.itemWidth ? item.itemWidth : this.props.defaultItemSize}]}>
-            <Text style={[item.titleStyle ? item.titleStyle : this.props.defaultTitleStyle, styles.titleText]}>
-              {item.title}
-            </Text>
-            {item.titleInfo ?
-              <Text style={[styles.rightSideStyle, {color: '#B1B1B1'}, item.titleInfoStyle]}>
-                {item.titleInfo}
-              </Text>
-              : null}
+            {titleInfoPosition === 'Bottom' ?
+                <View style={{flexDirection:'column',flex:1,justifyContent:'center'}}>
+                    {this._itemTitleBlock(item, index, 'Bottom')}
+                </View>
+              : this._itemTitleBlock(item, index)}
+
             {item.rightSideContent ? item.rightSideContent : null}
             {item.hasSwitch ?
               <Switch
@@ -276,6 +302,10 @@ SettingsList.Item = React.createClass({
      */
     titleInfo: React.PropTypes.string,
     titleInfoStyle: Text.propTypes.style,
+    /**
+     * If 'Bottom', info is placed beneath the title
+     */
+    titleInfoPosition: React.PropTypes.string,
     /**
      * Right side content
      */


### PR DESCRIPTION
Setting either of these to 'Bottom' will move the info text to underneath the title text. As is the default on Android settings.