### PR TITLE
use default editableText style if none supplied

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ class SettingsList extends React.Component {
         item.isEditable ?
         <TextInput
               key={item.id}
-              style={item.editableTextStyle ? item.editableTextStyle : item.editableText}
+              style={item.editableTextStyle ? item.editableTextStyle : styles.editableText}
               placeholder = {item.placeholder}
               onChangeText={(text) => item.onTextChange(text)}
               value={item.value} />


### PR DESCRIPTION
There's a typo which prevents `editableText` items from being rendered if `item.editableTextStyle` isn't defined.

Fixes #25 