### PR TITLE
Use prop-types module instead of React.propTypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import {
   View,
@@ -17,13 +18,13 @@ const ARROW_ICON = require('./img/icon-arrow-settings.png');
 
 class SettingsList extends React.Component {
   static propTypes = {
-    backgroundColor: React.PropTypes.string,
-    borderColor: React.PropTypes.string,
-    defaultItemSize: React.PropTypes.number,
-    underlayColor: React.PropTypes.string,
+    backgroundColor: PropTypes.string,
+    borderColor: PropTypes.string,
+    defaultItemSize: PropTypes.number,
+    underlayColor: PropTypes.string,
     defaultTitleStyle: Text.propTypes.style,
-    defaultTitleInfoPosition: React.PropTypes.string,
-    scrollViewProps: React.PropTypes.object,
+    defaultTitleInfoPosition: PropTypes.string,
+    scrollViewProps: PropTypes.object,
   };
 
   static defaultProps ={
@@ -264,7 +265,7 @@ const styles = StyleSheet.create({
  */
 SettingsList.Header = React.createClass({
   propTypes: {
-    headerText: React.PropTypes.string,
+    headerText: PropTypes.string,
     headerStyle: Text.propTypes.style,
   },
   /**
@@ -283,12 +284,12 @@ SettingsList.Item = React.createClass({
     /**
      * Title being displayed
      */
-    title: React.PropTypes.string,
+    title: PropTypes.string,
     titleStyle: Text.propTypes.style,
     /**
      * Icon displayed on the left of the settings item
      */
-    icon: React.PropTypes.node,
+    icon: PropTypes.node,
 
     /**
      * Item Box Style
@@ -310,68 +311,68 @@ SettingsList.Item = React.createClass({
     /**
      * Individual item width.  Can be globally set in the parent.  Will become deprecated
      */
-    itemWidth: React.PropTypes.number,
+    itemWidth: PropTypes.number,
     /**
      * Allows for the item to become an auth item
      */
-    isAuth: React.PropTypes.bool,
-    authPropsUser: React.PropTypes.object,
-    authPropsPW: React.PropTypes.object,
+    isAuth: PropTypes.bool,
+    authPropsUser: PropTypes.object,
+    authPropsPW: PropTypes.object,
     /**
      * Individual background color. Can be globally set in the parent. Will become Deprecated
      */
-    backgroundColor: React.PropTypes.string,
+    backgroundColor: PropTypes.string,
 
     /**
      * Individual underlay click color.  Can be globally set in the parent.
      */
-    underlayColor: React.PropTypes.string,
+    underlayColor: PropTypes.string,
     /**
      * Item on press callback.
      */
-    onPress: React.PropTypes.func,
+    onPress: PropTypes.func,
     /**
      * Item on long press callback.
      */
-    onLongPress: React.PropTypes.func,
+    onLongPress: PropTypes.func,
     /**
      * Enable or disable the > arrow at the end of the setting item.
      */
-    hasNavArrow: React.PropTypes.bool,
-    arrowIcon: React.PropTypes.node,
+    hasNavArrow: PropTypes.bool,
+    arrowIcon: PropTypes.node,
 
     arrowStyle: Image.propTypes.style,
     /**
      * Enable or disable a Switch component
      */
-    hasSwitch: React.PropTypes.bool,
+    hasSwitch: PropTypes.bool,
     /**
      * Switch state
      */
-    switchState: React.PropTypes.bool,
+    switchState: PropTypes.bool,
     /**
      * Switch props
      */
-    switchProps: React.PropTypes.object,
+    switchProps: PropTypes.object,
     /**
      * On value change callback
      */
-    switchOnValueChange: React.PropTypes.func,
+    switchOnValueChange: PropTypes.func,
     /**
      * Right side information on the setting item
      */
-    titleInfo: React.PropTypes.string,
+    titleInfo: PropTypes.string,
     titleInfoStyle: Text.propTypes.style,
     /**
      * If 'Bottom', info is placed beneath the title
      */
-    titleInfoPosition: React.PropTypes.string,
+    titleInfoPosition: PropTypes.string,
     /**
      * Right side content
      */
-    rightSideContent: React.PropTypes.node,
+    rightSideContent: PropTypes.node,
     /* Gives opens to hide specific borders */
-    borderHide: React.PropTypes.oneOf(['Top', 'Bottom', 'Both'])
+    borderHide: PropTypes.oneOf(['Top', 'Bottom', 'Both'])
   },
   getDefaultProps(){
     return {

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "devDependencies": {
     "react-native": ">=0.18.0",
     "react": ">=0.14.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
Using `React.propTypes` is deprecated as of React v15.5, see [React documentation](https://facebook.github.io/react/docs/typechecking-with-proptypes.html)