### PR TITLE
Fix bottom border when header is only item in group

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,27 +79,30 @@ class SettingsList extends React.Component {
   }
 
   _groupView(group, index){
+    let items;
+    if (group.items.length > 0) {
+      items = (
+        <View style={{borderTopWidth:1, borderBottomWidth:1, borderColor: this.props.borderColor}}>
+          {group.items.map((item, index) => {
+            return this._itemView(item,index, group.items.length);
+          })}
+        </View>
+      );
+    }
+
     if(group.header){
       return (
         <View key={'group_' + index}>
           {group.other}
           <Text style={[{margin:5},group.header.headerStyle]} numberOfLines={1} ellipsizeMode="tail">{group.header.headerText}</Text>
-          <View style={{borderTopWidth:1, borderBottomWidth:1, borderColor: this.props.borderColor}}>
-            {group.items.map((item, index) => {
-              return this._itemView(item,index, group.items.length);
-            })}
-          </View>
+          {items}
         </View>
       )
     } else {
       return (
         <View key={'group_' + index}>
           {group.other}
-          <View style={{borderTopWidth:1, borderBottomWidth:1, borderColor: this.props.borderColor}}>
-            {group.items.map((item, index) => {
-              return this._itemView(item,index, group.items.length);
-            })}
-          </View>
+          {items}
         </View>
       )
     }


### PR DESCRIPTION
We use SettingsList.Header to add extra padding below list items, or to
add explanation text below an item (like the Display Zoom item in iPhone
Settings > Display & Brightness: https://goo.gl/kVLEs5). Currently,
react-native-notifications inserts a group below each header, even if
the group is empty, which adds a border below the header. This commit
only renders a group if there are items in the group to show.