### PR TITLE
Add support for changing Header numberOfLines

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ class SettingsList extends React.Component {
       return (
         <View key={'group_' + index}>
           {group.other}
-          <Text style={[{margin:5},group.header.headerStyle]} numberOfLines={1} ellipsizeMode="tail">{group.header.headerText}</Text>
+          <Text style={[{margin:5},group.header.headerStyle]} numberOfLines={group.header.headerNumberOfLines} ellipsizeMode="tail">{group.header.headerText}</Text>
           <View style={{borderTopWidth:1, borderBottomWidth:1, borderColor: this.props.borderColor}}>
             {group.items.map((item, index) => {
               return this._itemView(item,index, group.items.length);
@@ -266,6 +266,12 @@ SettingsList.Header = React.createClass({
   propTypes: {
     headerText: React.PropTypes.string,
     headerStyle: Text.propTypes.style,
+    headerNumberOfLines: React.PropTypes.number,
+  },
+  getDefaultProps() {
+    return {
+      headerNumberOfLines: 1,
+    };
   },
   /**
    * not directly rendered


### PR DESCRIPTION
Add a headerNumberOfLines prop that can override the number of lines
shown for SettingsList.Header