### PR TITLE
Added RN props option, textInputProps to pass into text input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ import SettingsList from 'react-native-settings-list';
 ###### <a href='#top'>Top</a>
 
 ## <a name='#new'>New changes/additions</a>
+* Added `textInputProps` passed to \<SettingsList.Item> to set other options such as `secureEntry` or `autoCapitalize`
 * Ability for an authorization-type component [example updated to show a practical use]
  * Allows for complete customization of the TextInput by passing into the two props authPropsUser and authPassPW (overwrites defaults
  * Uses existing onPress prop for callback
@@ -100,6 +101,7 @@ The following props are used:
 | authPropsUser       | Changes the props for the first TextInput component; overwrites default                                  | React.PropTypes.node   |
 | authPropsPW         | Changes the props for the second TextInput component; overwrites default                                 | React.PropTypes.node   |
 | itemRef             | Sets a `ref` on the TouchableHighlight that SettingsList.Item renders to                                 | React.PropTypes.func   |
+| textInputProps      | RN text input props                                                                                      | React.PropTypes.object |
 
 ###### <a href='#top'>Top</a>
 

--- a/index.js
+++ b/index.js
@@ -128,7 +128,8 @@ class SettingsList extends React.Component {
               style={item.editableTextStyle ? item.editableTextStyle : styles.editableText}
               placeholder = {item.placeholder}
               onChangeText={(text) => item.onTextChange(text)}
-              value={item.value} />
+              value={item.value}
+              {...item.textInputProps} />
         : null
     ])
   }
@@ -210,7 +211,7 @@ class SettingsList extends React.Component {
           <View style={item.titleBoxStyle ? item.titleBoxStyle : [styles.titleBox, border, {minHeight:item.itemWidth ? item.itemWidth : this.props.defaultItemSize}]}>
             {titleInfoPosition === 'Bottom' ?
                 <View style={{flexDirection:'column',flex:1,justifyContent:'center'}}>
-                    {item.isEditable ? this._itemEditableBlock(item, inde, 'Bottom') : this._itemTitleBlock(item, index, 'Bottom')}
+                    {item.isEditable ? this._itemEditableBlock(item, index, 'Bottom') : this._itemTitleBlock(item, index, 'Bottom')}
                 </View>
               : item.isEditable ? this._itemEditableBlock(item, index) : this._itemTitleBlock(item, index)}
 


### PR DESCRIPTION
Building on top of https://github.com/evetstech/react-native-settings-list/pull/49, but with a bit of README. This is very useful for all kinds of available text input properties, similar to switch properties. Some may very well be exposed on the parent component, but this is at least future proof and works for `secureEntry` or `autoCapitalize` right now.

![text-input-props](https://user-images.githubusercontent.com/542335/42778162-38502610-890a-11e8-8ca7-cb97cf5473d8.gif)

```js
                    <SettingsList.Item 
                      id='password' 
                      title='password' 
                      isEditable={true} 
                      hasNavArrow={false}
                      titleStyle={styles.settingsItemTitle}
                      textInputProps={{
                        autoCapitalize: 'none',
                        secureTextEntry: true
                      }}
                      onTextChange={(text) => this.setState({ 
                        user: { 
                          ...this.state.user,
                          password: text
                        },
                        dirty: true
                      })}
                    />
```